### PR TITLE
Return current window location href as API url

### DIFF
--- a/src/angular/osww-frontend/src/app/api.service.ts
+++ b/src/angular/osww-frontend/src/app/api.service.ts
@@ -40,7 +40,21 @@ export class ApiService {
   constructor(private http: HttpClient) { }
 
   static constructURL(): string {
-    return environment.apiUrl + "/api/";
+    if (
+      window.location.href.includes('127.0.0.1') ||
+      window.location.href.includes('localhost')
+    ) {
+      return environment.apiUrl + "/api/";
+    } else {
+      // remove single trailing '/'
+      const sanitizedHref =
+        window.location.href.substring(window.location.href.length - 1) ===
+        '/'
+          ? window.location.href.substring(0, window.location.href.length - 1)
+          : window.location.href;
+
+      return sanitizedHref + "/api/";
+    }
   }
 
   getShouldRefresh() {


### PR DESCRIPTION
With this change, the API URL which is used by the frontend is always the same like the URL for the frontend itself.
Only if the frontend is loaded from localhost / 127.0.0.1, i.e. during local development of the frontend, the API call is sent towards winderoo.local, i.e. to the backend running on the ESP32.

This is a workaround for the mDNS issue on Android in #39 and should hopefully not break anything else. With this it's possible to load the frontend from the ESP32 IP instead of the winderoo.local domain provided by mDNS.