### PR TITLE
Address timer not working

### DIFF
--- a/src/platformio/osww-server/src/main.cpp
+++ b/src/platformio/osww-server/src/main.cpp
@@ -132,11 +132,20 @@ void getTime()
 	{
 		JsonDocument json;
 		deserializeJson(json, http.getStream());
-		const unsigned long epoch = json["unixtime"];
-		const unsigned long offset = json["raw_offset"];
+		const String datetime = json["datetime"];
 
-		rtc.offset = offset;
-		rtc.setTime(epoch);
+		String date = datetime.substring(0, datetime.indexOf("T") - 1);
+		int day = date.substring(8, 10).toInt();
+		int month = date.substring(5, 7).toInt();
+		int year = date.substring(0, 4).toInt();
+		
+		String time = datetime.substring(datetime.indexOf("T") + 1);
+		int seconds = time.substring(6, 8).toInt();
+		int hours = time.substring(0, 2).toInt();
+		int minutes = time.substring(3, 5).toInt();
+
+		rtc.setTime(seconds, minutes, hours, day, month, year);
+		Serial.println("[STATUS] - Time: " + datetime);
 	}
 
 	http.end();


### PR DESCRIPTION
Related discussion - >https://github.com/mwood77/winderoo/discussions/10

A few months late, but the discussion here was correct. The epoch/offset combination fed into the ESP32's rtc was not behaving correctly. This PR manually splits the timestamp and instantiates the rtc based off those ints.