### PR TITLE
move 'Winding Complete' status update for HA out of OLED_ENABLED conditional

### DIFF
--- a/src/platformio/osww-server/src/main.cpp
+++ b/src/platformio/osww-server/src/main.cpp
@@ -1894,8 +1894,9 @@ void loop()
 			if (OLED_ENABLED && !userDefinedSettings.screenSleep)
 			{
 				drawNotification("Winding Complete");
-				if (HOME_ASSISTANT_ENABLED) ha_activityState.setValue("Winding Complete");
 			}
+
+			if (HOME_ASSISTANT_ENABLED) ha_activityState.setValue("Winding Complete");
 
 			bool writeSuccess = writeConfigVarsToFile(settingsFile, userDefinedSettings);
 			if ( !writeSuccess )


### PR DESCRIPTION
When winding completed, the status on HA never updated, and would just stay as "Winding". This would stop the scheduled winding functionality from working, since it thought winding was already in progress.

I realised this is because I was using HA with no screen attached, and the logic to change the status was inside the conditional for the OLED screen.

Moving this out of that conditional block allows HA to get the status update regardless of if there's a screen installed or not.